### PR TITLE
Add faker /w factorybot to modify seeding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'sqlite3', git: "https://github.com/larskanis/sqlite3-ruby", branch: "add-gemspec"
 # Use Puma as the app server
+  gem 'faker'
+  gem 'factory_bot_rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,13 @@ GEM
       warden (~> 1.2.3)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.1.1)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
+    faker (2.2.1)
+      i18n (>= 0.8)
     ffi (1.10.0)
     ffi (1.10.0-x64-mingw32)
     ffi (1.10.0-x86-mingw32)
@@ -201,6 +208,8 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   devise
+  factory_bot_rails
+  faker
   jbuilder (~> 2.5)
   pg
   puma (~> 3.7)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,5 @@
 class Movie < ApplicationRecord
-    has_many :events, dependent: :destroy
+  has_many :events, dependent: :destroy
 
-    validates_presence_of :name, :duration, :synopsis, :genre, :trailer, :image, :big_image
+  validates_presence_of :name, :duration, :synopsis, :genre, :trailer, :image, :big_image
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-    in_time=Movie.create(name: "In time",duration: 109, synopsis: "Un hombre es acusado de asesinato y debe encontrar la forma de acabar con un sistema en donde el tiempo es dinero, permitiéndole a los ricos vivir para siempre, mientras los pobres ruegan por cada minuto de vida.",genre: "Suspenso, Ciencia ficcion", trailer: "https://www.youtube.com/embed/fdadZ_KrZVw", image: "https://www.youtube.com/embed/fdadZ_KrZVw",big_image: "https://image.tmdb.org/t/p/w1280/W2qS7hjH5Ic5a90a1HU2UC6MDw.jpg")
-    
-    
+in_time = Movie.create(name: "In time",duration: 109, synopsis: "Un hombre es acusado de asesinato y debe encontrar la forma de acabar con un sistema en donde el tiempo es dinero, permitiéndole a los ricos vivir para siempre, mientras los pobres ruegan por cada minuto de vida.",genre: "Suspenso, Ciencia ficcion", trailer: "https://www.youtube.com/embed/fdadZ_KrZVw", image: "https://www.youtube.com/embed/fdadZ_KrZVw",big_image: "https://image.tmdb.org/t/p/w1280/W2qS7hjH5Ic5a90a1HU2UC6MDw.jpg")
     #Movie.create([{name: "",duration: ,synopsis: "", genre: "", trailer: "", image: "", big_image: ""])
     #Movie.create([{name: "",duration: ,synopsis: "", genre: "", trailer: "", image: "", big_image: ""])
     #Movie.create([{name: "",duration: ,synopsis: "", genre: "", trailer: "", image: "", big_image: ""])
     #Movie.create([{name: "",duration: ,synopsis: "", genre: "", trailer: "", image: "", big_image: ""])
     #Movie.create([{name: "",duration: ,synopsis: "", genre: "", trailer: "", image: "", big_image: ""])
+
+# Creates 20 events /w 20 movies associated with it
+FactoryBot.create_list(:event, 20)
+

--- a/factories/event.rb
+++ b/factories/event.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :event do
+    association :movie
+    date { Faker::Date.between(from: 3.months.ago, to: 3.months.from_now) }
+    time_start { Faker::Time.between(from: 1.hours.from_now, to: 2.hours.from_now) }
+    time_end { Faker::Time.between(from: 2.hours.from_now, to: 3.hours.from_now) }
+    capacity { 60 }
+    hall { Faker::Name.name }
+  end
+end

--- a/factories/movie.rb
+++ b/factories/movie.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :movie do
+    name { Faker::Movie.quote }
+    duration { 60 }
+    synopsis { Faker::Lorem.words }
+    genre { Faker::Name.name }
+    trailer { Faker::Internet.url }
+    image { Faker::Internet.url }
+    big_image { Faker::Internet.url }
+  end
+end


### PR DESCRIPTION
This PR adds `factory_bot` with `faker` to make seeding the database easier. [FactoryBot](https://github.com/thoughtbot/factory_bot) enables us to define how to create and build models for us. [Faker](https://github.com/faker-ruby/faker) is a gem that generates random data for us. Using the two we can generate a wild variety of data more easily.

You should be able to do `rake db:seed` and get up to 20 random events now.